### PR TITLE
Added two collectors to Flashblade exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ The exporter accepts the following command line flags:
 # TYPE flashblade_perf_writes_per_sec gauge
 ```
 
+## Authors
+Prometheus FlashBlade Exporter has been under development at Man Group since 2019 and welcomes contributions.
+
+* [Michael Captain](https://github.com/macaptain), Man Group
+* [Advait Bhatwdekar] (https://github.com/You-NeverKnow) Hudson River Trading LLC
+
 ## TODO
 
 - [ ] Exit the exporter on startup (instead of scrape) if the API token variable isn't set

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ The exporter accepts the following command line flags:
 ```
 
 ## Authors
-Prometheus FlashBlade Exporter has been under development at Man Group since 2019 and welcomes contributions.
+Under development since 2019
 
 * [Michael Captain](https://github.com/macaptain), Man Group
-* [Advait Bhatwdekar] (https://github.com/You-NeverKnow) Hudson River Trading LLC
+* [Advait Bhatwdekar](https://github.com/You-NeverKnow), Hudson River Trading LLC
 
 ## TODO
 

--- a/collector/alerts.go
+++ b/collector/alerts.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package collector
 
 import (

--- a/collector/array_performance.go
+++ b/collector/array_performance.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package collector
 
 import (

--- a/collector/blades.go
+++ b/collector/blades.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package collector
 
 import (

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -24,21 +24,24 @@ type FlashbladeCollector struct {
 	subcollectors []Subcollector
 }
 
-func NewFlashbladeCollector(fbClient *fb.FlashbladeClient) *FlashbladeCollector {
+func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool) *FlashbladeCollector {
 	alertsCollector := NewAlertsCollector(fbClient)
 	arrayPerformanceCollector := NewArrayPerformanceCollector(fbClient)
 	bladesCollector := NewBladesCollector(fbClient)
 	filesystemsCollector := NewFilesystemsCollector(fbClient)
-	usageCollector := NewUsageCollector(fbClient)
-	fsPerformanceCollector := NewFSPerformanceCollector(fbClient)
 
 	subcollectors := []Subcollector{
 		alertsCollector,
 		arrayPerformanceCollector,
 		bladesCollector,
 		filesystemsCollector,
-		usageCollector,
-		fsPerformanceCollector,
+	}
+
+	if fsMetricFlag {
+		usageCollector := NewUsageCollector(fbClient)
+		fsPerformanceCollector := NewFSPerformanceCollector(fbClient)
+	
+		subcollectors = append(subcollectors, usageCollector, fsPerformanceCollector)
 	}
 
 	return &FlashbladeCollector{subcollectors: subcollectors}

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package collector
 

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
 package collector
 
 import (
@@ -26,8 +29,17 @@ func NewFlashbladeCollector(fbClient *fb.FlashbladeClient) *FlashbladeCollector 
 	arrayPerformanceCollector := NewArrayPerformanceCollector(fbClient)
 	bladesCollector := NewBladesCollector(fbClient)
 	filesystemsCollector := NewFilesystemsCollector(fbClient)
+	usageCollector := NewUsageCollector(fbClient)
+	fsPerformanceCollector := NewFSPerformanceCollector(fbClient)
 
-	subcollectors := []Subcollector{alertsCollector, arrayPerformanceCollector, bladesCollector, filesystemsCollector}
+	subcollectors := []Subcollector{
+		alertsCollector,
+		arrayPerformanceCollector,
+		bladesCollector,
+		filesystemsCollector,
+		usageCollector,
+		fsPerformanceCollector,
+	}
 
 	return &FlashbladeCollector{subcollectors: subcollectors}
 }

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -1,5 +1,21 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
 // Copyright (c) 2019 Hudson River Trading LLC
 // All rights reserved.
+//
 
 package collector
 

--- a/collector/filesystems.go
+++ b/collector/filesystems.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package collector
 
 import (

--- a/collector/fs_performance.go
+++ b/collector/fs_performance.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package collector
 

--- a/collector/fs_performance.go
+++ b/collector/fs_performance.go
@@ -1,5 +1,21 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
 // Copyright (c) 2019 Hudson River Trading LLC
 // All rights reserved.
+//
 
 package collector
 

--- a/collector/fs_performance.go
+++ b/collector/fs_performance.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
+package collector
+
+import (
+	"github.com/manahl/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type FSPerformanceCollector struct {
+	fbClient         *fb.FlashbladeClient
+	BytesPerOp       *prometheus.Desc
+	BytesPerRead     *prometheus.Desc
+	BytesPerWrite    *prometheus.Desc
+	OthersPerSec     *prometheus.Desc
+	ReadsPerSec      *prometheus.Desc
+	ReadBytesPerSec  *prometheus.Desc
+	UsecPerOtherOp   *prometheus.Desc
+	UsecPerReadOp    *prometheus.Desc
+	UsecPerWriteOp   *prometheus.Desc
+	WritesPerSec     *prometheus.Desc
+	WriteBytesPerSec *prometheus.Desc
+}
+
+func NewFSPerformanceCollector(fbClient *fb.FlashbladeClient) *FSPerformanceCollector {
+	const subsystem = "fs_performance"
+
+	return &FSPerformanceCollector{
+		fbClient: fbClient,
+		BytesPerOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_operation"),
+			"Average operation size (read bytes+write bytes/(read operations + write operations))",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		BytesPerRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_read"),
+			"Average read size in bytes per read operation",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		BytesPerWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_write"),
+			"Average write size in bytes per write operation",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		OthersPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "non_read_write_operations_per_second"),
+			"All operations except read processed per second",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "reads_per_second"),
+			"Read requests processed per second",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadBytesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_bytes_per_second"),
+			"Read byte requests processed per second",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerOtherOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_non_read_write_operation"),
+			"Average time, measured in seconds, that the array takes to process other operations",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_read_operation"),
+			"Average time, measured in seconds, that the array takes to process a read request",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_write_operation"),
+			"Average time, measured in seconds, that the array takes to process a write request",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+
+		WritesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "writes_per_second"),
+			"Write requests processed per second",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteBytesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_bytes_per_second"),
+			"Write byte requests processed per second",
+			[]string{"name"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c FSPerformanceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting quota metrics", err)
+	}
+}
+
+func (c FSPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
+	stats, err := c.fbClient.FSPerformance()
+	if err != nil {
+		return err
+	}
+
+	for _, stat := range stats.Items {
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesPerOp,
+			prometheus.GaugeValue,
+			float64(stat.BytesPerOp),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesPerRead,
+			prometheus.GaugeValue,
+			float64(stat.BytesPerRead),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.BytesPerWrite,
+			prometheus.GaugeValue,
+			float64(stat.BytesPerWrite),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.OthersPerSec,
+			prometheus.GaugeValue,
+			float64(stat.OthersPerSec),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadsPerSec,
+			prometheus.GaugeValue,
+			float64(stat.ReadsPerSec),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ReadBytesPerSec,
+			prometheus.GaugeValue,
+			float64(stat.ReadBytesPerSec),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.UsecPerOtherOp,
+			prometheus.GaugeValue,
+			float64(stat.UsecPerOtherOp) / 1e6,
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.UsecPerReadOp,
+			prometheus.GaugeValue,
+			float64(stat.UsecPerReadOp) / 1e6,
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.UsecPerWriteOp,
+			prometheus.GaugeValue,
+			float64(stat.UsecPerWriteOp) / 1000,
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.WritesPerSec,
+			prometheus.GaugeValue,
+			float64(stat.WritesPerSec),
+			stat.Name,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.WriteBytesPerSec,
+			prometheus.GaugeValue,
+			float64(stat.WriteBytesPerSec),
+			stat.Name,
+		)
+	}
+
+	return nil
+}

--- a/collector/usage.go
+++ b/collector/usage.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package collector
 

--- a/collector/usage.go
+++ b/collector/usage.go
@@ -1,5 +1,21 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
 // Copyright (c) 2019 Hudson River Trading LLC
 // All rights reserved.
+//
 
 package collector
 

--- a/collector/usage.go
+++ b/collector/usage.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
+package collector
+
+import (
+	"github.com/manahl/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+
+	"strconv"
+)
+
+type UsageCollector struct {
+	fbClient *fb.FlashbladeClient
+	Usage    *prometheus.Desc
+	Quota    *prometheus.Desc
+}
+
+func NewUsageCollector(fbClient *fb.FlashbladeClient) *UsageCollector {
+	const subsystem = "usagequota"
+
+	return &UsageCollector{
+		fbClient: fbClient,
+		Usage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "memory_usage_bytes"),
+			"Usage of a user/group on a filesystem in bytes",
+			[]string{"type", "name", "id", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		Quota: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "memory_quota_bytes"),
+			"Quota of a user/group on a filesystem in bytes",
+			[]string{"type", "name", "id", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c UsageCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting Usage metrics", err)
+	}
+}
+
+func (c UsageCollector) collect(ch chan<- prometheus.Metric) error {
+	usage, err := c.fbClient.Usage()
+	if err != nil {
+		return err
+	}
+
+	userUsage, groupUsage := usage.Users, usage.Groups
+
+	for _, usage := range userUsage {
+		for _, data := range usage.Items {
+			ch <- prometheus.MustNewConstMetric(
+				c.Usage,
+				prometheus.GaugeValue,
+				float64(data.Usage),
+				"user", data.User.Name, strconv.FormatInt(int64(data.User.Id), 10), data.FileSystem["name"])
+
+			ch <- prometheus.MustNewConstMetric(
+				c.Quota,
+				prometheus.GaugeValue,
+				float64(data.Quota),
+				"user", data.User.Name, strconv.FormatInt(int64(data.User.Id), 10), data.FileSystem["name"])
+		}
+	}
+
+	for _, usage := range groupUsage {
+		for _, data := range usage.Items {
+			ch <- prometheus.MustNewConstMetric(
+				c.Usage,
+				prometheus.GaugeValue,
+				float64(data.Usage),
+				"group", data.Group.Name, strconv.FormatInt(int64(data.Group.Id), 10), data.FileSystem["name"])
+			
+			ch <- prometheus.MustNewConstMetric( 
+				c.Quota,
+				prometheus.GaugeValue,
+				float64(data.Quota),
+				"group", data.Group.Name, strconv.FormatInt(int64(data.Group.Id), 10), data.FileSystem["name"])	
+		}
+	}
+	return nil
+}

--- a/fb/alerts.go
+++ b/fb/alerts.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package fb
 
 type AlertsResponse struct {

--- a/fb/array_performance.go
+++ b/fb/array_performance.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package fb
 
 type ArrayPerformanceResponse struct {

--- a/fb/blades.go
+++ b/fb/blades.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package fb
 
 type BladesResponse struct {

--- a/fb/filesystems.go
+++ b/fb/filesystems.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
 package fb
 
 type FilesystemsResponse struct {

--- a/fb/fs_performance.go
+++ b/fb/fs_performance.go
@@ -1,5 +1,21 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
 // Copyright (c) 2019 Hudson River Trading LLC
 // All rights reserved.
+//
 
 package fb
 

--- a/fb/fs_performance.go
+++ b/fb/fs_performance.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package fb
 

--- a/fb/fs_performance.go
+++ b/fb/fs_performance.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
+package fb
+
+type FSPerformanceResponse struct {
+	Items []FSPerformanceItem `json:"items"`
+}
+
+type FSPerformanceItem struct {
+	Name             string  `json:"name"`
+	BytesPerOp       float64 `json:"bytes_per_op"`
+	BytesPerRead     float64 `json:"bytes_per_read"`
+	BytesPerWrite    float64 `json:"bytes_per_write"`
+	OthersPerSec     float64 `json:"others_per_sec"`
+	ReadBytesPerSec  float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec      float64 `json:"reads_per_sec"`
+	Time             float64 `json:"time"`
+	UsecPerOtherOp   float64 `json:"usec_per_other_op"`
+	UsecPerReadOp    float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp   float64 `json:"usec_per_write_op"`
+	WritesPerSec     float64 `json:"writes_per_sec"`
+	WriteBytesPerSec float64 `json:"write_bytes_per_sec"`
+}
+
+func (fbClient FlashbladeClient) FSPerformance() (FSPerformanceResponse, error) {
+	endpoint := "/1.8/file-systems/performance"
+	params := make(map[string]string)
+	params["protocol"] = "nfs" // Only NFS supported as of API 1.8
+
+	var fsPerformance FSPerformanceResponse
+	err := fbClient.GetJSON(endpoint, params, &fsPerformance)
+	return fsPerformance, err
+}

--- a/fb/http.go
+++ b/fb/http.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
 package fb
 
 import (
@@ -21,16 +24,21 @@ type FlashbladeClient struct {
 
 func NewFlashbladeClient(host string, insecure bool) *FlashbladeClient {
 	client := &http.Client{}
+	var fb FlashbladeClient
+
 	if insecure {
 		transport := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client = &http.Client{Transport: transport}
 	}
-	return &FlashbladeClient{
-		client: client,
-		Host:   host,
-	}
+
+	fb = FlashbladeClient{client: client, Host: host}
+
+	// Init x-auth-token
+	fb.refreshXAuthToken()
+
+	return &fb
 }
 
 func getAPITokenFromEnv() string {

--- a/fb/http.go
+++ b/fb/http.go
@@ -1,22 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
-
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package fb
 

--- a/fb/http.go
+++ b/fb/http.go
@@ -1,5 +1,22 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
 // Copyright (c) 2019 Hudson River Trading LLC
 // All rights reserved.
+//
+
 
 package fb
 

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -1,9 +1,6 @@
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-
 package fb
 
-import "github.com/prometheus/common/log"
+import "fmt"
 
 type UsageResponse struct {
 	Groups []UsageGroup
@@ -54,39 +51,33 @@ func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
 	err := fbClient.GetJSON(endpoint, nil, &filesystemsResponse)
 
 	if err != nil {
-		log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
+		fmt.Println("Error while getting JSON")
 		return UsageResponse{}, err
 	}
 
 	var (
 		usageResponseGroup []UsageGroup
 		usageResponseUser  []UsageUser
-		usageGroup UsageGroup
-		usageUser UsageUser
 	)
 	params := make(map[string]string)
 
 	for _, item := range filesystemsResponse.Items {
 		params["file_system_names"] = item.Name
 
+		usageResponseGroup = append(usageResponseGroup, UsageGroup{})
 		endpoint = "1.8/usage/groups"
-		err = fbClient.GetJSON(endpoint, params, &usageGroup)
-		if err != nil {
-			log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
-			return UsageResponse{}, err
-		}
-		usageResponseGroup = append(usageResponseGroup, usageGroup)
+		err = fbClient.GetJSON(endpoint, params, &(usageResponseGroup[len(usageResponseGroup)-1]))
 
-		endpoint = "1.8/usage/users"
-		err = fbClient.GetJSON(endpoint, params, &usageUser)
 		if err != nil {
-			log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
+			fmt.Println("Error while getting JSON")
 			return UsageResponse{}, err
 		}
-		
-		usageResponseUser = append(usageResponseUser, usageUser)
+
+		usageResponseUser = append(usageResponseUser, UsageUser{})
+		endpoint = "1.8/usage/users"
+		err = fbClient.GetJSON(endpoint, params, &(usageResponseUser)[len(usageResponseUser)-1])
 
 	}
 
-	return UsageResponse{usageResponseGroup, usageResponseUser}, nil
+	return UsageResponse{usageResponseGroup, usageResponseUser}, err
 }

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+
+package fb
+
+import "github.com/prometheus/common/log"
+
+type UsageResponse struct {
+	Groups []UsageGroup
+	Users  []UsageUser
+}
+
+type PaginationData struct {
+	ContinuationToken string `json:"continuation_token"`
+	Total             int    `json:"total_item_count"`
+}
+
+type UsageGroup struct {
+	Items          []UsageItemGroup `json:"items"`
+	PaginationInfo PaginationData   `json:"pagination_info"`
+}
+
+type UsageUser struct {
+	Items          []UsageItemUser `json:"items"`
+	PaginationInfo PaginationData  `json:"pagination_info"`
+}
+
+type UsageItemGroup struct {
+	FileSystem             map[string]string `json:"file_system"`
+	FileSystemDefaultQuota int               `json:"file_system_default_quota"`
+	Group                  NameID            `json:"group"`
+	Name                   string            `json:"name"`
+	Quota                  int               `json:"quota"`
+	Usage                  int               `json:"usage"`
+}
+
+type UsageItemUser struct {
+	FileSystem             map[string]string `json:"file_system"`
+	FileSystemDefaultQuota int               `json:"file_system_default_quota"`
+	User                   NameID            `json:"user"`
+	Name                   string            `json:"name"`
+	Quota                  int               `json:"quota"`
+	Usage                  int               `json:"usage"`
+}
+
+type NameID struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
+	endpoint := "1.8/file-systems"
+	var filesystemsResponse FilesystemsResponse
+	err := fbClient.GetJSON(endpoint, nil, &filesystemsResponse)
+
+	if err != nil {
+		log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
+		return UsageResponse{}, err
+	}
+
+	var (
+		usageResponseGroup []UsageGroup
+		usageResponseUser  []UsageUser
+		usageGroup UsageGroup
+		usageUser UsageUser
+	)
+	params := make(map[string]string)
+
+	for _, item := range filesystemsResponse.Items {
+		params["file_system_names"] = item.Name
+
+		endpoint = "1.8/usage/groups"
+		err = fbClient.GetJSON(endpoint, params, &usageGroup)
+		if err != nil {
+			log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
+			return UsageResponse{}, err
+		}
+		usageResponseGroup = append(usageResponseGroup, usageGroup)
+
+		endpoint = "1.8/usage/users"
+		err = fbClient.GetJSON(endpoint, params, &usageUser)
+		if err != nil {
+			log.Errorf("Error while getting JSON on endpoint %s", endpoint, err)
+			return UsageResponse{}, err
+		}
+		
+		usageResponseUser = append(usageResponseUser, usageUser)
+
+	}
+
+	return UsageResponse{usageResponseGroup, usageResponseUser}, nil
+}

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package fb
 

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -1,3 +1,22 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+//
+
 package fb
 
 import "fmt"

--- a/main.go
+++ b/main.go
@@ -1,21 +1,5 @@
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along
-// with this program; if not, write to the Free Software Foundation, Inc.,
-// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-//
-// Copyright (c) 2019 Hudson River Trading LLC
-// All rights reserved.
-//
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,22 @@
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Copyright (c) 2019 Hudson River Trading LLC
+// All rights reserved.
+//
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 var (
 	flashbladeFlag = kingpin.Arg("flashblade", "Address of the target Flashblade.").Required().String()
 	portFlag       = kingpin.Flag("port", "Port to listen on.").Short('p').Default("9130").String()
+	fsMetricFlag   = kingpin.Flag("filesystem-metrics", "Export filesystem and usage data metrics for each user and group.").Default("false").Bool()
 	insecureFlag   = kingpin.Flag("insecure", "Disable the verification of the SSL certificate").Default("false").Bool()
 )
 
@@ -34,7 +35,7 @@ func main() {
 	kingpin.Version("0.1.0")
 	kingpin.Parse()
 	fbClient := fb.NewFlashbladeClient(*flashbladeFlag, *insecureFlag)
-	fbCollector := collector.NewFlashbladeCollector(fbClient)
+	fbCollector := collector.NewFlashbladeCollector(fbClient, *fsMetricFlag)
 	prometheus.MustRegister(fbCollector)
 	listen()
 }


### PR DESCRIPTION
- Added collector for usage statistics for each user and group on every filesystem.

```
# HELP flashblade_usagequota_memory_quota_bytes Quota of a user/group on a filesystem in bytes
# TYPE flashblade_usagequota_memory_quota_bytes gauge
# HELP flashblade_usagequota_memory_usage_bytes Usage of a user/group on a filesystem in bytes
# TYPE flashblade_usagequota_memory_usage_bytes gauge
```

- Added filesystem performance collector metrics.

```
# HELP flashblade_fs_performance_bytes_per_op Average operation size (read bytes+write bytes/(read ops+write ops))
# TYPE flashblade_fs_performance_bytes_per_op gauge
# HELP flashblade_fs_performance_bytes_per_read Average read size in bytes per read operation
# TYPE flashblade_fs_performance_bytes_per_read gauge
# HELP flashblade_fs_performance_bytes_per_write Average write size in bytes per write operation
# TYPE flashblade_fs_performance_bytes_per_write gauge
# HELP flashblade_fs_performance_non_read_write_operations_per_second All operations except read processed per second
# TYPE flashblade_fs_performance_non_read_write_operations_per_second gauge
# HELP flashblade_fs_performance_read_bytes_per_second Read byte requests processed per second
# TYPE flashblade_fs_performance_read_bytes_per_second gauge
# HELP flashblade_fs_performance_reads_per_second Read requests processed per second
# TYPE flashblade_fs_performance_reads_per_second gauge
# HELP flashblade_fs_performance_sec_per_non_read_write_op Average time, measured in seconds, that the array takes to process other operations
# TYPE flashblade_fs_performance_sec_per_non_read_write_op gauge
# HELP flashblade_fs_performance_sec_per_read_op Average time, measured in seconds, that the array takes to process a read request
# TYPE flashblade_fs_performance_sec_per_read_op gauge
# HELP flashblade_fs_performance_sec_per_write_op Average time, measured in seconds, that the array takes to process a write request
# TYPE flashblade_fs_performance_sec_per_write_op gauge
# HELP flashblade_fs_performance_write_bytes_per_second Write byte requests processed per second
# TYPE flashblade_fs_performance_write_bytes_per_second gauge
# HELP flashblade_fs_performance_writes_per_second Write requests processed per second
# TYPE flashblade_fs_performance_writes_per_second gauge
```

Also made a small change in `http.go` to initialize value of authorization token. 