### PR TITLE
 Add a collector to gather total capacity metrics from FlashBlade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,4 @@ EXPOSE 9130
 
 USER fbexporter:fbexporter
 
-# Run the compiled binary.
 ENTRYPOINT ["/usr/bin/prometheus-flashblade-exporter"]
-

--- a/README.md
+++ b/README.md
@@ -37,12 +37,8 @@ The exporter accepts the following command line flags:
 * Bandwidth, IOPS and latency for both read and write
 
 ```
-# HELP flashblade_alert_num_critical_alerts Number of open critical severity alerts
-# TYPE flashblade_alert_num_critical_alerts gauge
-# HELP flashblade_alert_num_info_alerts Number of open info severity alerts
-# TYPE flashblade_alert_num_info_alerts gauge
-# HELP flashblade_alert_num_warning_alerts Number of open warning severity alerts
-# TYPE flashblade_alert_num_warning_alerts gauge
+# HELP flashblade_alert_num_open Number of open alerts of each severity
+# TYPE flashblade_alert_num_open gauge
 # HELP flashblade_blade_num_healthy_blades Number of blades in healthy status
 # TYPE flashblade_blade_num_healthy_blades gauge
 # HELP flashblade_blade_num_unhealthy_blades Number of blades in a non-healthy status
@@ -81,6 +77,18 @@ The exporter accepts the following command line flags:
 # TYPE flashblade_perf_usec_per_write_op gauge
 # HELP flashblade_perf_writes_per_sec Write requests processed per second
 # TYPE flashblade_perf_writes_per_sec gauge
+# HELP flashblade_space_capacity_bytes Usable capacity in bytes
+# TYPE flashblade_space_capacity_bytes gauge
+# HELP flashblade_space_data_reduction Reduction of data
+# TYPE flashblade_space_data_reduction gauge
+# HELP flashblade_space_snapshot_usage_bytes Physical usage by snapshots, non-unique
+# TYPE flashblade_space_snapshot_usage_bytes gauge
+# HELP flashblade_space_total_usage_bytes Total physical usage (including snapshots) in bytes
+# TYPE flashblade_space_total_usage_bytes gauge
+# HELP flashblade_space_unique_usage_bytes Physical usage in bytes
+# TYPE flashblade_space_unique_usage_bytes gauge
+# HELP flashblade_space_virtual_usage_bytes Usage in bytes
+# TYPE flashblade_space_virtual_usage_bytes gauge
 ```
 
 ## TODO

--- a/collector/array_space.go
+++ b/collector/array_space.go
@@ -1,0 +1,106 @@
+package collector
+
+import (
+	"github.com/manahl/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type ArraySpaceCollector struct {
+	fbClient           *fb.FlashbladeClient
+	Capacity           *prometheus.Desc
+	VirtualUsage       *prometheus.Desc
+	DataReduction      *prometheus.Desc
+	UniqueUsage        *prometheus.Desc
+	SnapshotUsage      *prometheus.Desc
+	TotalPhysicalUsage *prometheus.Desc
+}
+
+func NewArraySpaceCollector(fbClient *fb.FlashbladeClient) *ArraySpaceCollector {
+	const subsystem = "space"
+
+	return &ArraySpaceCollector{
+		fbClient: fbClient,
+		Capacity: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "capacity_bytes"),
+			"Usable capacity in bytes",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		VirtualUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "virtual_usage_bytes"),
+			"Usage in bytes",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		DataReduction: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "data_reduction"),
+			"Reduction of data",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UniqueUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "unique_usage_bytes"),
+			"Physical usage in bytes",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		SnapshotUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "snapshot_usage_bytes"),
+			"Physical usage by snapshots, non-unique",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		TotalPhysicalUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "total_usage_bytes"),
+			"Total physical usage (including snapshots) in bytes",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting array performance metrics", err)
+	}
+}
+
+func (c ArraySpaceCollector) collect(ch chan<- prometheus.Metric) error {
+	stats, err := c.fbClient.ArraySpace()
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.Capacity,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Capacity))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.VirtualUsage,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Space.Virtual))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.DataReduction,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Space.DataReduction))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UniqueUsage,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Space.Unique))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.SnapshotUsage,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Space.Snapshots))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.TotalPhysicalUsage,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].Space.TotalPhysical))
+
+	return nil
+}

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -24,10 +24,11 @@ type FlashbladeCollector struct {
 func NewFlashbladeCollector(fbClient *fb.FlashbladeClient) *FlashbladeCollector {
 	alertsCollector := NewAlertsCollector(fbClient)
 	arrayPerformanceCollector := NewArrayPerformanceCollector(fbClient)
+	arraySpaceCollector := NewArraySpaceCollector(fbClient)
 	bladesCollector := NewBladesCollector(fbClient)
 	filesystemsCollector := NewFilesystemsCollector(fbClient)
 
-	subcollectors := []Subcollector{alertsCollector, arrayPerformanceCollector, bladesCollector, filesystemsCollector}
+	subcollectors := []Subcollector{alertsCollector, arrayPerformanceCollector, arraySpaceCollector, bladesCollector, filesystemsCollector}
 
 	return &FlashbladeCollector{subcollectors: subcollectors}
 }

--- a/fb/array_space.go
+++ b/fb/array_space.go
@@ -1,0 +1,20 @@
+package fb
+
+type ArraySpaceResponse struct {
+	Items [1]ArraySpaceItem `json:"items"`
+}
+
+type ArraySpaceItem struct {
+	Name     string  `json:"name"`
+	Capacity float64 `json:"capacity"`
+	Parity   float64 `json:"parity"`
+	Space    Space   `json:"space"`
+	Time     float64 `json:"time"`
+}
+
+func (fbClient FlashbladeClient) ArraySpace() (ArraySpaceResponse, error) {
+	endpoint := "/1.2/arrays/space"
+	var arraySpaceResponse ArraySpaceResponse
+	err := fbClient.GetJSON(endpoint, nil, &arraySpaceResponse)
+	return arraySpaceResponse, err
+}


### PR DESCRIPTION
The capacity metrics are collected from the /arrays/space endpoint and appear as follows:

```
# HELP flashblade_space_capacity_bytes Usable capacity in bytes
# TYPE flashblade_space_capacity_bytes gauge
# HELP flashblade_space_data_reduction Reduction of data
# TYPE flashblade_space_data_reduction gauge
# HELP flashblade_space_snapshot_usage_bytes Physical usage by snapshots, non-unique
# TYPE flashblade_space_snapshot_usage_bytes gauge
# HELP flashblade_space_total_usage_bytes Total physical usage (including snapshots) in bytes
# TYPE flashblade_space_total_usage_bytes gauge
# HELP flashblade_space_unique_usage_bytes Physical usage in bytes
# TYPE flashblade_space_unique_usage_bytes gauge
# HELP flashblade_space_virtual_usage_bytes Usage in bytes
# TYPE flashblade_space_virtual_usage_bytes gauge
```

Plus, a small fix to the readme (correction to the alert metric names) and tidy up a comment from the Dockerfile.