### PR TITLE
Expose basic metrics for S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Prometheus FlashBlade Exporter has been under development since 2019 and welcome
 
 * [Michael Captain](https://github.com/macaptain), Man Group
 * [Advait Bhatwdekar](https://github.com/You-NeverKnow), Hudson River Trading LLC
+* [Jeff Patti](https://github.com/jepatti), Man Group

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -30,6 +30,7 @@ func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool) *F
 	arraySpaceCollector := NewArraySpaceCollector(fbClient)
 	bladesCollector := NewBladesCollector(fbClient)
 	filesystemsCollector := NewFilesystemsCollector(fbClient)
+	s3BucketsCollector := NewS3BucketsCollector(fbClient)
 
 	subcollectors := []Subcollector{
 		alertsCollector,
@@ -37,6 +38,7 @@ func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool) *F
 		arraySpaceCollector,
 		bladesCollector,
 		filesystemsCollector,
+		s3BucketsCollector,
 	}
 
 	if fsMetricFlag {

--- a/collector/s3_buckets.go
+++ b/collector/s3_buckets.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package collector
+
+import (
+	"github.com/manahl/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type S3BucketsCollector struct {
+	fbClient           *fb.FlashbladeClient
+	VirtualUsage       *prometheus.Desc
+	DataReduction      *prometheus.Desc
+	UniqueUsage        *prometheus.Desc
+	SnapshotUsage      *prometheus.Desc
+	TotalPhysicalUsage *prometheus.Desc
+	ObjectCount        *prometheus.Desc
+}
+
+func NewS3BucketsCollector(fbClient *fb.FlashbladeClient) *S3BucketsCollector {
+	const subsystem = "s3"
+
+	return &S3BucketsCollector{
+		fbClient: fbClient,
+		VirtualUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "virtual_usage_bytes"),
+			"Usage in bytes",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		DataReduction: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "data_reduction"),
+			"Reduction of data",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UniqueUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "unique_usage_bytes"),
+			"Physical usage in bytes",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		SnapshotUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "snapshot_usage_bytes"),
+			"Physical usage by snapshots, non-unique",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		TotalPhysicalUsage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "total_usage_bytes"),
+			"Total physical usage (including snapshots) in bytes",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ObjectCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "object_count"),
+			"The number of object within the bucket.",
+			[]string{"bucket"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c S3BucketsCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting s3 blade metrics", err)
+	}
+}
+
+func (c S3BucketsCollector) collect(ch chan<- prometheus.Metric) error {
+	s3_buckets, err := c.fbClient.S3Buckets()
+	if err != nil {
+		return err
+	}
+
+	for _, s3_bucket := range s3_buckets.Items {
+		ch <- prometheus.MustNewConstMetric(
+			c.VirtualUsage,
+			prometheus.GaugeValue,
+			float64(s3_bucket.Space.Virtual),
+			s3_bucket.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.DataReduction,
+			prometheus.GaugeValue,
+			float64(s3_bucket.Space.DataReduction),
+			s3_bucket.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.UniqueUsage,
+			prometheus.GaugeValue,
+			float64(s3_bucket.Space.Unique),
+			s3_bucket.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.SnapshotUsage,
+			prometheus.GaugeValue,
+			float64(s3_bucket.Space.Snapshots),
+			s3_bucket.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.TotalPhysicalUsage,
+			prometheus.GaugeValue,
+			float64(s3_bucket.Space.TotalPhysical),
+			s3_bucket.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.ObjectCount,
+			prometheus.GaugeValue,
+			float64(s3_bucket.ObjectCount),
+			s3_bucket.Name)
+	}
+
+	return nil
+}

--- a/fb/common.go
+++ b/fb/common.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package fb
+
+type Space struct {
+	Virtual       int     `json:"virtual"`
+	DataReduction float64 `json:"data_reduction"`
+	Unique        int     `json:"unique"`
+	Snapshots     int     `json:"snapshots"`
+	TotalPhysical int     `json:"total_physical"`
+}

--- a/fb/filesystems.go
+++ b/fb/filesystems.go
@@ -22,14 +22,6 @@ type FilesystemsItem struct {
 	TimeRemaining              int         `json:"time_remaining"`
 }
 
-type Space struct {
-	Virtual       int     `json:"virtual"`
-	DataReduction float64 `json:"data_reduction"`
-	Unique        int     `json:"unique"`
-	Snapshots     int     `json:"snapshots"`
-	TotalPhysical int     `json:"total_physical"`
-}
-
 func (fbClient FlashbladeClient) Filesystems() (FilesystemsResponse, error) {
 	endpoint := "/1.2/file-systems"
 	var filesystemsResponse FilesystemsResponse

--- a/fb/s3_buckets.go
+++ b/fb/s3_buckets.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package fb
+
+type S3BucketsResponse struct {
+	Total BucketItem   `json:"total"`
+	Items []BucketItem `json:"items"`
+}
+
+type BucketItem struct {
+	Name          string `json:"name"`
+	Created       int    `json:"created"`
+	Space         Space  `json:"space"`
+	Destroyed     bool   `json:"destroyed"`
+	TimeRemaining int    `json:"time_remaining"`
+	ObjectCount   int    `json:"object_count"`
+	Versioning    string `json:"versioning"`
+}
+
+func (fbClient FlashbladeClient) S3Buckets() (S3BucketsResponse, error) {
+	endpoint := "/1.3/buckets"
+	var s3BucketsResponse S3BucketsResponse
+	err := fbClient.GetJSON(endpoint, nil, &s3BucketsResponse)
+	return s3BucketsResponse, err
+}


### PR DESCRIPTION
Expose useful metrics like used size and object count.

More on this API call can be found at:
https://purity-fb.readthedocs.io/en/latest/BucketsApi/#list_buckets

The response type is:
https://purity-fb.readthedocs.io/en/latest/BucketResponse/

Testing done: Ran the changes locally and saw that the `flashblade_s3_object_count`, `flashblade_s3_virtual_usage_bytes`, and others match the expected results from `curl`ing the buckets endpoint. This is my first golang contribution, so please let me know if I've violated any golang norms.