### PR TITLE
Added dynamic api version for GET requests

### DIFF
--- a/collector/fs_performance.go
+++ b/collector/fs_performance.go
@@ -171,7 +171,7 @@ func (c FSPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.UsecPerWriteOp,
 			prometheus.GaugeValue,
-			float64(stat.UsecPerWriteOp)/1000,
+			float64(stat.UsecPerWriteOp)/1e6,
 			stat.Name,
 		)
 

--- a/fb/alerts.go
+++ b/fb/alerts.go
@@ -26,7 +26,7 @@ type AlertsItem struct {
 }
 
 func (fbClient FlashbladeClient) OpenAlerts() (AlertsResponse, error) {
-	endpoint := "/1.2/alerts"
+	endpoint := "alerts"
 	var alertsResponse AlertsResponse
 	params := make(map[string]string)
 	params["filter"] = "state='open'"

--- a/fb/array_performance.go
+++ b/fb/array_performance.go
@@ -24,7 +24,7 @@ type ArrayPerformanceItem struct {
 }
 
 func (fbClient FlashbladeClient) ArrayPerformance() (ArrayPerformanceResponse, error) {
-	endpoint := "/1.2/arrays/performance"
+	endpoint := "arrays/performance"
 	var arrayPerformanceResponse ArrayPerformanceResponse
 	err := fbClient.GetJSON(endpoint, nil, &arrayPerformanceResponse)
 	return arrayPerformanceResponse, err

--- a/fb/array_space.go
+++ b/fb/array_space.go
@@ -16,7 +16,7 @@ type ArraySpaceItem struct {
 }
 
 func (fbClient FlashbladeClient) ArraySpace() (ArraySpaceResponse, error) {
-	endpoint := "/1.2/arrays/space"
+	endpoint := "arrays/space"
 	var arraySpaceResponse ArraySpaceResponse
 	err := fbClient.GetJSON(endpoint, nil, &arraySpaceResponse)
 	return arraySpaceResponse, err

--- a/fb/blades.go
+++ b/fb/blades.go
@@ -17,7 +17,7 @@ type BladesItem struct {
 }
 
 func (fbClient FlashbladeClient) Blades() (BladesResponse, error) {
-	endpoint := "/1.2/blades"
+	endpoint := "blades"
 	var bladesResponse BladesResponse
 	err := fbClient.GetJSON(endpoint, nil, &bladesResponse)
 	return bladesResponse, err

--- a/fb/filesystems.go
+++ b/fb/filesystems.go
@@ -23,7 +23,7 @@ type FilesystemsItem struct {
 }
 
 func (fbClient FlashbladeClient) Filesystems() (FilesystemsResponse, error) {
-	endpoint := "/1.2/file-systems"
+	endpoint := "file-systems"
 	var filesystemsResponse FilesystemsResponse
 	err := fbClient.GetJSON(endpoint, nil, &filesystemsResponse)
 	return filesystemsResponse, err

--- a/fb/fs_performance.go
+++ b/fb/fs_performance.go
@@ -3,6 +3,8 @@
 
 package fb
 
+import "path"
+
 type FSPerformanceResponse struct {
 	Items []FSPerformanceItem `json:"items"`
 }
@@ -24,7 +26,8 @@ type FSPerformanceItem struct {
 }
 
 func (fbClient FlashbladeClient) FSPerformance() (FSPerformanceResponse, error) {
-	endpoint := "/1.8/file-systems/performance"
+	endpoint := path.Join(fbClient.ApiVersion, "/file-systems/performance")
+
 	params := make(map[string]string)
 	params["protocol"] = "nfs" // Only NFS supported as of API 1.8
 

--- a/fb/fs_performance.go
+++ b/fb/fs_performance.go
@@ -3,8 +3,6 @@
 
 package fb
 
-import "path"
-
 type FSPerformanceResponse struct {
 	Items []FSPerformanceItem `json:"items"`
 }
@@ -26,7 +24,7 @@ type FSPerformanceItem struct {
 }
 
 func (fbClient FlashbladeClient) FSPerformance() (FSPerformanceResponse, error) {
-	endpoint := path.Join(fbClient.ApiVersion, "/file-systems/performance")
+	endpoint := "file-systems/performance"
 
 	params := make(map[string]string)
 	params["protocol"] = "nfs" // Only NFS supported as of API 1.8

--- a/fb/http.go
+++ b/fb/http.go
@@ -18,8 +18,13 @@ import (
 var xAuthToken string
 
 type FlashbladeClient struct {
-	Host   string
-	client *http.Client
+	Host       string
+	client     *http.Client
+	ApiVersion string
+}
+
+type Version struct {
+	Versions []string `json:"versions"`
 }
 
 func NewFlashbladeClient(host string, insecure bool) *FlashbladeClient {
@@ -37,8 +42,21 @@ func NewFlashbladeClient(host string, insecure bool) *FlashbladeClient {
 
 	// Init x-auth-token
 	fb.refreshXAuthToken()
+	fb.ApiVersion = fb.getAPIVersion()
 
 	return &fb
+}
+
+func (fbClient *FlashbladeClient) getAPIVersion() string {
+	var (
+		params map[string]string
+		v      Version
+	)
+	err := fbClient.GetJSON("api_version", params, &v)
+	if err != nil {
+		log.Fatalln("Failed to get supported API-versions. Error =", err)
+	}
+	return v.Versions[len(v.Versions)-1]
 }
 
 func getAPITokenFromEnv() string {

--- a/fb/http.go
+++ b/fb/http.go
@@ -90,7 +90,7 @@ func (fbClient *FlashbladeClient) refreshXAuthToken() {
 
 func (fbClient *FlashbladeClient) urlForEndpoint(endpoint string) string {
 	u, _ := url.Parse(fmt.Sprintf("https://%s/api", fbClient.Host))
-	u.Path = path.Join(u.Path, endpoint)
+	u.Path = path.Join(u.Path, fbClient.ApiVersion, endpoint)
 	return u.String()
 }
 

--- a/fb/http.go
+++ b/fb/http.go
@@ -141,7 +141,10 @@ func (fbClient *FlashbladeClient) Get(endpoint string, params map[string]string)
 		if resp.StatusCode == http.StatusForbidden {
 			log.Fatalln("Couldn't authenticate with the given token")
 		}
+	} else if resp.StatusCode != 200 {
+		log.Printf("Failed GET with status %d for %v", resp.StatusCode, resp.Request.URL.String())
 	}
+
 	return resp
 }
 

--- a/fb/http.go
+++ b/fb/http.go
@@ -60,8 +60,8 @@ func (fbClient *FlashbladeClient) getAPIVersion(selectedVersion string) string {
 
 	latestVersion := v.Versions[len(v.Versions)-1]
 
-	latestMajorVersion, latestMinorVersion := getVersionsToCompare(latestVersion)
-	selectedMajorVersion, selectedMinorVersion := getVersionsToCompare(selectedVersion)
+	latestMajorVersion, latestMinorVersion := splitDecimal(latestVersion)
+	selectedMajorVersion, selectedMinorVersion := splitDecimal(selectedVersion)
 
 	apiVersion := selectedVersion
 
@@ -74,7 +74,7 @@ func (fbClient *FlashbladeClient) getAPIVersion(selectedVersion string) string {
 	return apiVersion
 }
 
-func getVersionsToCompare(versionStr string) (int64, int64) {
+func splitDecimal(versionStr string) (int64, int64) {
 	decimal := strings.Split(versionStr, ".")
 	intPart, err := strconv.ParseInt(decimal[0], 10, 32)
 

--- a/fb/s3_buckets.go
+++ b/fb/s3_buckets.go
@@ -19,7 +19,7 @@ type BucketItem struct {
 }
 
 func (fbClient FlashbladeClient) S3Buckets() (S3BucketsResponse, error) {
-	endpoint := "/1.3/buckets"
+	endpoint := "buckets"
 	var s3BucketsResponse S3BucketsResponse
 	err := fbClient.GetJSON(endpoint, nil, &s3BucketsResponse)
 	return s3BucketsResponse, err

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -5,7 +5,6 @@ package fb
 
 import (
 	"fmt"
-	"path"
 )
 
 type UsageResponse struct {
@@ -20,12 +19,12 @@ type PaginationData struct {
 
 type UsageGroup struct {
 	Items          []UsageItemGroup `json:"items"`
-	//PaginationInfo PaginationData   `json:"pagination_info"`
+	PaginationInfo PaginationData   `json:"pagination_info"`
 }
 
 type UsageUser struct {
 	Items          []UsageItemUser `json:"items"`
-	//PaginationInfo PaginationData  `json:"pagination_info"`
+	PaginationInfo PaginationData  `json:"pagination_info"`
 }
 
 type UsageItemGroup struct {
@@ -52,7 +51,7 @@ type NameID struct {
 }
 
 func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
-	endpoint := path.Join(fbClient.ApiVersion, "/file-systems")
+	endpoint := "file-systems"
 	var filesystemsResponse FilesystemsResponse
 	err := fbClient.GetJSON(endpoint, nil, &filesystemsResponse)
 
@@ -71,7 +70,7 @@ func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
 		params["file_system_names"] = item.Name
 
 		usageResponseGroup = append(usageResponseGroup, UsageGroup{})
-		endpoint = path.Join(fbClient.ApiVersion, "/usage/groups")
+		endpoint = "usage/groups"
 
 		err = fbClient.GetJSON(endpoint, params, &(usageResponseGroup[len(usageResponseGroup)-1]))
 
@@ -81,9 +80,8 @@ func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
 		}
 
 		usageResponseUser = append(usageResponseUser, UsageUser{})
-		endpoint = path.Join(fbClient.ApiVersion, "/usage/users")
+		endpoint = "usage/users"
 		err = fbClient.GetJSON(endpoint, params, &(usageResponseUser)[len(usageResponseUser)-1])
-
 	}
 
 	return UsageResponse{usageResponseGroup, usageResponseUser}, err

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -3,7 +3,10 @@
 
 package fb
 
-import "fmt"
+import (
+	"fmt"
+	"path"
+)
 
 type UsageResponse struct {
 	Groups []UsageGroup
@@ -49,7 +52,7 @@ type NameID struct {
 }
 
 func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
-	endpoint := "1.8/file-systems"
+	endpoint := path.Join(fbClient.ApiVersion, "/file-systems")
 	var filesystemsResponse FilesystemsResponse
 	err := fbClient.GetJSON(endpoint, nil, &filesystemsResponse)
 
@@ -68,7 +71,8 @@ func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
 		params["file_system_names"] = item.Name
 
 		usageResponseGroup = append(usageResponseGroup, UsageGroup{})
-		endpoint = "1.8/usage/groups"
+		endpoint = path.Join(fbClient.ApiVersion, "/usage/groups")
+
 		err = fbClient.GetJSON(endpoint, params, &(usageResponseGroup[len(usageResponseGroup)-1]))
 
 		if err != nil {
@@ -77,7 +81,7 @@ func (fbClient FlashbladeClient) Usage() (UsageResponse, error) {
 		}
 
 		usageResponseUser = append(usageResponseUser, UsageUser{})
-		endpoint = "1.8/usage/users"
+		endpoint = path.Join(fbClient.ApiVersion, "/usage/users")
 		err = fbClient.GetJSON(endpoint, params, &(usageResponseUser)[len(usageResponseUser)-1])
 
 	}

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -20,12 +20,12 @@ type PaginationData struct {
 
 type UsageGroup struct {
 	Items          []UsageItemGroup `json:"items"`
-	PaginationInfo PaginationData   `json:"pagination_info"`
+	//PaginationInfo PaginationData   `json:"pagination_info"`
 }
 
 type UsageUser struct {
 	Items          []UsageItemUser `json:"items"`
-	PaginationInfo PaginationData  `json:"pagination_info"`
+	//PaginationInfo PaginationData  `json:"pagination_info"`
 }
 
 type UsageItemGroup struct {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var (
 	portFlag       = kingpin.Flag("port", "Port to listen on.").Short('p').Default("9130").String()
 	fsMetricFlag   = kingpin.Flag("filesystem-metrics", "Export filesystem and usage data metrics for each user and group.").Default("false").Bool()
 	insecureFlag   = kingpin.Flag("insecure", "Disable the verification of the SSL certificate").Default("false").Bool()
-	apiVersionFlag = kingpin.Flag("apiVersion", "API version to query the flashblade").Default("1.7").String()
+	apiVersionFlag = kingpin.Flag("api-version", "API version to query the flashblade").Default("1.7").String()
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	portFlag       = kingpin.Flag("port", "Port to listen on.").Short('p').Default("9130").String()
 	fsMetricFlag   = kingpin.Flag("filesystem-metrics", "Export filesystem and usage data metrics for each user and group.").Default("false").Bool()
 	insecureFlag   = kingpin.Flag("insecure", "Disable the verification of the SSL certificate").Default("false").Bool()
+	apiVersionFlag = kingpin.Flag("apiVersion", "API version to query the flashblade").Default("1.7").String()
 )
 
 func init() {
@@ -37,7 +38,7 @@ func listen() {
 func main() {
 	kingpin.Version("0.3.0")
 	kingpin.Parse()
-	fbClient := fb.NewFlashbladeClient(*flashbladeFlag, *insecureFlag)
+	fbClient := fb.NewFlashbladeClient(*flashbladeFlag, *insecureFlag, *apiVersionFlag)
 	fbCollector := collector.NewFlashbladeCollector(fbClient, *fsMetricFlag)
 	prometheus.MustRegister(fbCollector)
 	listen()


### PR DESCRIPTION
Hey, I have updated a couple of files to use the latest API version supported by the server dynamically. Currently, only collectors enabled by `--filesystem-metrics` flag use this "feature". 

I noticed that all the other collectors use api-v1.2 or api-v1.3. Do you want me to update them to dynamically use the latest version supported by the server as well?

The PR also includes a fix: Fixed `flashblade_fs_performance_seconds_per_write_operation` reporting incorrect seconds value 

