### PR TITLE
Add NFS, HTTP and S3 protocol specific performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ The exporter accepts the following command line flags:
 * FlashBlade total capacity and usage
 * Usage statistics for each user and group per filesystem (with `--filesystem-metrics`)
 * Filesystem performance (with `--filesystem-metrics`)
+* S3 and HTTP specific performance metrics
+* NFS specific performance metrics (requires FlashBlade API version 1.9)
 
 ```
-# HELP flashblade_alert_num_open Number of open alerts of each severity
-# TYPE flashblade_alert_num_open gauge
+# HELP flashblade_alert_alert_total Number of open alerts
+# TYPE flashblade_alert_alert_total gauge
 # HELP flashblade_blade_num_healthy_blades Number of blades in healthy status
 # TYPE flashblade_blade_num_healthy_blades gauge
 # HELP flashblade_blade_num_unhealthy_blades Number of blades in a non-healthy status
@@ -70,14 +72,150 @@ The exporter accepts the following command line flags:
 # TYPE flashblade_perf_bytes_per_read gauge
 # HELP flashblade_perf_bytes_per_write Average write size in bytes per write operation
 # TYPE flashblade_perf_bytes_per_write gauge
+# HELP flashblade_perf_http_others_per_sec Other operations processed per second
+# TYPE flashblade_perf_http_others_per_sec gauge
+# HELP flashblade_perf_http_read_dirs_per_sec Read directories requests processed per second
+# TYPE flashblade_perf_http_read_dirs_per_sec gauge
+# HELP flashblade_perf_http_read_files_per_sec Read files requests processed per second
+# TYPE flashblade_perf_http_read_files_per_sec gauge
+# HELP flashblade_perf_http_usec_per_other_op Average time, measured in microseconds, that the array takes to process other operations
+# TYPE flashblade_perf_http_usec_per_other_op gauge
+# HELP flashblade_perf_http_usec_per_read_dir_op Average time, measured in microseconds, that the array takes to process a read directory request
+# TYPE flashblade_perf_http_usec_per_read_dir_op gauge
+# HELP flashblade_perf_http_usec_per_read_file_op Average time, measured in microseconds, that the array takes to process a read file request
+# TYPE flashblade_perf_http_usec_per_read_file_op gauge
+# HELP flashblade_perf_http_usec_per_write_dir_op Average time, measured in microseconds, that the array takes to process a write directory request
+# TYPE flashblade_perf_http_usec_per_write_dir_op gauge
+# HELP flashblade_perf_http_usec_per_write_file_op Average time, measured in microseconds, that the array takes to process a write file request
+# TYPE flashblade_perf_http_usec_per_write_file_op gauge
+# HELP flashblade_perf_http_write_dirs_per_sec Write directories requests processed per second
+# TYPE flashblade_perf_http_write_dirs_per_sec gauge
+# HELP flashblade_perf_http_write_files_per_sec Write files requests processed per second
+# TYPE flashblade_perf_http_write_files_per_sec gauge
 # HELP flashblade_perf_input_per_sec Bytes written per second
 # TYPE flashblade_perf_input_per_sec gauge
+# HELP flashblade_perf_nfs_accesses_per_sec ACCESS requests processed per second
+# TYPE flashblade_perf_nfs_accesses_per_sec gauge
+# HELP flashblade_perf_nfs_aggregate_file_metadata_creates_per_sec Sum of file-level or directory-level create-like metadata requests per second. Includes CREATE, LINK, MKDIR, and SYMLINK
+# TYPE flashblade_perf_nfs_aggregate_file_metadata_creates_per_sec gauge
+# HELP flashblade_perf_nfs_aggregate_file_metadata_modifies_per_sec Sum of file-level or directory-level modify-like and delete-like metadata requests per second. Includes REMOVE, RENAME, RMDIR, and SETATTR
+# TYPE flashblade_perf_nfs_aggregate_file_metadata_modifies_per_sec gauge
+# HELP flashblade_perf_nfs_aggregate_file_metadata_reads_per_sec Sum of file-level or directory-level read-like metadata requests per second. Includes GETATTR, LOOKUP, PATHCONF, READDIR, READDIRPLUS, and READLINK
+# TYPE flashblade_perf_nfs_aggregate_file_metadata_reads_per_sec gauge
+# HELP flashblade_perf_nfs_aggregate_share_metadata_reads_per_sec Sum of share-level read-like metadata requests per second. Includes ACCESS, FSINFO, and FSSTAT
+# TYPE flashblade_perf_nfs_aggregate_share_metadata_reads_per_sec gauge
+# HELP flashblade_perf_nfs_aggregate_usec_per_file_metadata_create_op Average time, measured in microseconds, it takes the array to process a file-level or directory-level create-like metadata request. Includes CREATE, LINK, MKDIR, and SYMLINK
+# TYPE flashblade_perf_nfs_aggregate_usec_per_file_metadata_create_op gauge
+# HELP flashblade_perf_nfs_aggregate_usec_per_file_metadata_modify_op Average time, measured in microseconds, it takes the array to process a file-level or directory-level modify-like or delete-like metadata request. Includes REMOVE, RENAME, RMDIR, and SETATTR
+# TYPE flashblade_perf_nfs_aggregate_usec_per_file_metadata_modify_op gauge
+# HELP flashblade_perf_nfs_aggregate_usec_per_file_metadata_read_op Average time, measured in microseconds, it takes the array to process a file-level or directory-level read-like metadata request. Includes GETATTR, LOOKUP, PATHCONF, READDIR, READDIRPLUS, and READLINK
+# TYPE flashblade_perf_nfs_aggregate_usec_per_file_metadata_read_op gauge
+# HELP flashblade_perf_nfs_aggregate_usec_per_share_metadata_read_op Average time, measured in microseconds, it takes the array to process a share-level read-like metadata request. Includes ACCESS, FSINFO, and FSSTAT
+# TYPE flashblade_perf_nfs_aggregate_usec_per_share_metadata_read_op gauge
+# HELP flashblade_perf_nfs_creates_per_sec CREATE requests processed per second
+# TYPE flashblade_perf_nfs_creates_per_sec gauge
+# HELP flashblade_perf_nfs_fsinfos_per_sec FSINFO requests processed per second
+# TYPE flashblade_perf_nfs_fsinfos_per_sec gauge
+# HELP flashblade_perf_nfs_fsstats_per_sec FSSTAT requests processed per second
+# TYPE flashblade_perf_nfs_fsstats_per_sec gauge
+# HELP flashblade_perf_nfs_getattrs_per_sec GETATTR requests processed per second
+# TYPE flashblade_perf_nfs_getattrs_per_sec gauge
+# HELP flashblade_perf_nfs_links_per_sec LINK requests processed per second
+# TYPE flashblade_perf_nfs_links_per_sec gauge
+# HELP flashblade_perf_nfs_lookups_per_sec LOOKUP requests processed per second
+# TYPE flashblade_perf_nfs_lookups_per_sec gauge
+# HELP flashblade_perf_nfs_mkdirs_per_sec MKDIR requests processed per second
+# TYPE flashblade_perf_nfs_mkdirs_per_sec gauge
+# HELP flashblade_perf_nfs_others_per_sec All other requests processed per second
+# TYPE flashblade_perf_nfs_others_per_sec gauge
+# HELP flashblade_perf_nfs_pathconfs_per_sec PATHCONF requests processed per second
+# TYPE flashblade_perf_nfs_pathconfs_per_sec gauge
+# HELP flashblade_perf_nfs_readdirpluses_per_sec READDIRPLUS requests processed per second
+# TYPE flashblade_perf_nfs_readdirpluses_per_sec gauge
+# HELP flashblade_perf_nfs_readdirs_per_sec READDIR requests processed per second
+# TYPE flashblade_perf_nfs_readdirs_per_sec gauge
+# HELP flashblade_perf_nfs_readlinks_per_sec READLINK requests processed per second
+# TYPE flashblade_perf_nfs_readlinks_per_sec gauge
+# HELP flashblade_perf_nfs_reads_per_sec READ requests processed per second
+# TYPE flashblade_perf_nfs_reads_per_sec gauge
+# HELP flashblade_perf_nfs_removes_per_sec REMOVE requests processed per second
+# TYPE flashblade_perf_nfs_removes_per_sec gauge
+# HELP flashblade_perf_nfs_renames_per_sec RENAME requests processed per second
+# TYPE flashblade_perf_nfs_renames_per_sec gauge
+# HELP flashblade_perf_nfs_rmdirs_per_sec RMDIR requests processed per second
+# TYPE flashblade_perf_nfs_rmdirs_per_sec gauge
+# HELP flashblade_perf_nfs_setattrs_per_sec SETATTR requests processed per second
+# TYPE flashblade_perf_nfs_setattrs_per_sec gauge
+# HELP flashblade_perf_nfs_symlinks_per_sec SYMLINK requests processed per second
+# TYPE flashblade_perf_nfs_symlinks_per_sec gauge
+# HELP flashblade_perf_nfs_usec_per_access_op Average time, measured in microseconds, it takes the array to process an ACCESS request
+# TYPE flashblade_perf_nfs_usec_per_access_op gauge
+# HELP flashblade_perf_nfs_usec_per_create_op Average time, measured in microseconds, it takes the array to process a CREATE request
+# TYPE flashblade_perf_nfs_usec_per_create_op gauge
+# HELP flashblade_perf_nfs_usec_per_fsinfo_op Average time, measured in microseconds, it takes the array to process an FSINFO request
+# TYPE flashblade_perf_nfs_usec_per_fsinfo_op gauge
+# HELP flashblade_perf_nfs_usec_per_fsstat_op Average time, measured in microseconds, it takes the array to process an FSSTAT request
+# TYPE flashblade_perf_nfs_usec_per_fsstat_op gauge
+# HELP flashblade_perf_nfs_usec_per_getattr_op Average time, measured in microseconds, it takes the array to process a GETATTR request
+# TYPE flashblade_perf_nfs_usec_per_getattr_op gauge
+# HELP flashblade_perf_nfs_usec_per_link_op Average time, measured in microseconds, it takes the array to process a LINK request
+# TYPE flashblade_perf_nfs_usec_per_link_op gauge
+# HELP flashblade_perf_nfs_usec_per_lookup_op Average time, measured in microseconds, it takes the array to process a LOOKUP request
+# TYPE flashblade_perf_nfs_usec_per_lookup_op gauge
+# HELP flashblade_perf_nfs_usec_per_mkdir_op Average time, measured in microseconds, it takes the array to process a MKDIR request
+# TYPE flashblade_perf_nfs_usec_per_mkdir_op gauge
+# HELP flashblade_perf_nfs_usec_per_other_op Average time, measured in microseconds, it takes the array to process all other requests
+# TYPE flashblade_perf_nfs_usec_per_other_op gauge
+# HELP flashblade_perf_nfs_usec_per_pathconf_op Average time, measured in microseconds, it takes the array to process a PATHCONF request
+# TYPE flashblade_perf_nfs_usec_per_pathconf_op gauge
+# HELP flashblade_perf_nfs_usec_per_read_op Average time, measured in microseconds, it takes the array to process a READ request
+# TYPE flashblade_perf_nfs_usec_per_read_op gauge
+# HELP flashblade_perf_nfs_usec_per_readdir_op Average time, measured in microseconds, it takes the array to process a READDIR request
+# TYPE flashblade_perf_nfs_usec_per_readdir_op gauge
+# HELP flashblade_perf_nfs_usec_per_readdir_plus_op Average time, measured in microseconds, it takes the array to process a READDIRPLUS request
+# TYPE flashblade_perf_nfs_usec_per_readdir_plus_op gauge
+# HELP flashblade_perf_nfs_usec_per_readlink_op Average time, measured in microseconds, it takes the array to process a READLINK request
+# TYPE flashblade_perf_nfs_usec_per_readlink_op gauge
+# HELP flashblade_perf_nfs_usec_per_remove_op Average time, measured in microseconds, it takes the array to process a REMOVE request
+# TYPE flashblade_perf_nfs_usec_per_remove_op gauge
+# HELP flashblade_perf_nfs_usec_per_rename_op Average time, measured in microseconds, it takes the array to process a RENAME request
+# TYPE flashblade_perf_nfs_usec_per_rename_op gauge
+# HELP flashblade_perf_nfs_usec_per_rmdir_op Average time, measured in microseconds, it takes the array to process an RMDIR request
+# TYPE flashblade_perf_nfs_usec_per_rmdir_op gauge
+# HELP flashblade_perf_nfs_usec_per_setattr_op Average time, measured in microseconds, it takes the array to process a SETATTR request
+# TYPE flashblade_perf_nfs_usec_per_setattr_op gauge
+# HELP flashblade_perf_nfs_usec_per_symlink_op Average time, measured in microseconds, it takes the array to process a SYMLINK request
+# TYPE flashblade_perf_nfs_usec_per_symlink_op gauge
+# HELP flashblade_perf_nfs_usec_per_write_op Average time, measured in microseconds, it takes the array to process a WRITE request
+# TYPE flashblade_perf_nfs_usec_per_write_op gauge
+# HELP flashblade_perf_nfs_writes_per_sec WRITE requests processed per second
+# TYPE flashblade_perf_nfs_writes_per_sec gauge
 # HELP flashblade_perf_others_per_sec Other operations processed per second
 # TYPE flashblade_perf_others_per_sec gauge
 # HELP flashblade_perf_output_per_sec Bytes read per second
 # TYPE flashblade_perf_output_per_sec gauge
 # HELP flashblade_perf_reads_per_sec Read requests processed per second
 # TYPE flashblade_perf_reads_per_sec gauge
+# HELP flashblade_perf_s3_others_per_sec Other operations processed per second
+# TYPE flashblade_perf_s3_others_per_sec gauge
+# HELP flashblade_perf_s3_read_buckets_per_sec Read bucket requests processed per second
+# TYPE flashblade_perf_s3_read_buckets_per_sec gauge
+# HELP flashblade_perf_s3_read_objects_per_sec Read object requests processed per second
+# TYPE flashblade_perf_s3_read_objects_per_sec gauge
+# HELP flashblade_perf_s3_usec_per_other_op Average time, measured in microseconds, that the array takes to process other operations
+# TYPE flashblade_perf_s3_usec_per_other_op gauge
+# HELP flashblade_perf_s3_usec_per_read_bucket_op Average time, measured in microseconds, that the array takes to process a read bucket request
+# TYPE flashblade_perf_s3_usec_per_read_bucket_op gauge
+# HELP flashblade_perf_s3_usec_per_read_object_op Average time, measured in microseconds, that the array takes to process a read object request
+# TYPE flashblade_perf_s3_usec_per_read_object_op gauge
+# HELP flashblade_perf_s3_usec_per_write_bucket_op Average time, measured in microseconds, that the array takes to process a write bucket request
+# TYPE flashblade_perf_s3_usec_per_write_bucket_op gauge
+# HELP flashblade_perf_s3_usec_per_write_object_op Average time, measured in microseconds, that the array takes to process a write object request
+# TYPE flashblade_perf_s3_usec_per_write_object_op gauge
+# HELP flashblade_perf_s3_write_buckets_per_sec Write bucket requests processed per second
+# TYPE flashblade_perf_s3_write_buckets_per_sec gauge
+# HELP flashblade_perf_s3_write_objects_per_sec Write object requests processed per second
+# TYPE flashblade_perf_s3_write_objects_per_sec gauge
 # HELP flashblade_perf_usec_per_other_op Average time, measured in microseconds, that the array takes to process other operations
 # TYPE flashblade_perf_usec_per_other_op gauge
 # HELP flashblade_perf_usec_per_read_op Average time, measured in microseconds, that the array takes to process a read request

--- a/collector/array_http_performance.go
+++ b/collector/array_http_performance.go
@@ -1,0 +1,156 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package collector
+
+import (
+	"github.com/man-group/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type ArrayHttpPerformanceCollector struct {
+	fbClient           *fb.FlashbladeClient
+	ReadDirsPerSec     *prometheus.Desc
+	WriteDirsPerSec    *prometheus.Desc
+	ReadFilesPerSec    *prometheus.Desc
+	WriteFilesPerSec   *prometheus.Desc
+	OthersPerSec       *prometheus.Desc
+	UsecPerReadDirOp   *prometheus.Desc
+	UsecPerWriteDirOp  *prometheus.Desc
+	UsecPerReadFileOp  *prometheus.Desc
+	UsecPerWriteFileOp *prometheus.Desc
+	UsecPerOtherOp     *prometheus.Desc
+}
+
+func NewArrayHttpPerformanceCollector(fbClient *fb.FlashbladeClient) *ArrayHttpPerformanceCollector {
+	const subsystem = "perf_http"
+
+	return &ArrayHttpPerformanceCollector{
+		fbClient: fbClient,
+		ReadDirsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_dirs_per_sec"),
+			"Read directories requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteDirsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_dirs_per_sec"),
+			"Write directories requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadFilesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_files_per_sec"),
+			"Read files requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteFilesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_files_per_sec"),
+			"Write files requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		OthersPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "others_per_sec"),
+			"Other operations processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadDirOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_read_dir_op"),
+			"Average time, measured in microseconds, that the array takes to process a read directory request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteDirOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_write_dir_op"),
+			"Average time, measured in microseconds, that the array takes to process a write directory request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadFileOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_read_file_op"),
+			"Average time, measured in microseconds, that the array takes to process a read file request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteFileOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_write_file_op"),
+			"Average time, measured in microseconds, that the array takes to process a write file request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerOtherOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_other_op"),
+			"Average time, measured in microseconds, that the array takes to process other operations",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+func (c ArrayHttpPerformanceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting array HTTP performance metrics", err)
+	}
+}
+
+func (c ArrayHttpPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
+	stats, err := c.fbClient.ArrayHttpPerformance()
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadDirsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReadDirsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.WriteDirsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].WriteDirsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadFilesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReadFilesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.WriteFilesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].WriteFilesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.OthersPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].OthersPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadDirOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadDirOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerWriteDirOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerWriteDirOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadFileOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadFileOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerWriteFileOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerWriteFileOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerOtherOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerOtherOp))
+
+	return nil
+}

--- a/collector/array_nfs_performance.go
+++ b/collector/array_nfs_performance.go
@@ -1,0 +1,613 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package collector
+
+import (
+	"github.com/man-group/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type ArrayNfsPerformanceCollector struct {
+	fbClient                             *fb.FlashbladeClient
+	AccessesPerSec                       *prometheus.Desc
+	AggregateFileMetadataCreatesPerSec   *prometheus.Desc
+	AggregateFileMetadataModifiesPerSec  *prometheus.Desc
+	AggregateFileMetadataReadsPerSec     *prometheus.Desc
+	AggregateShareMetadataReadsPerSec    *prometheus.Desc
+	AggregateUsecPerFileMetadataCreateOp *prometheus.Desc
+	AggregateUsecPerFileMetadataModifyOp *prometheus.Desc
+	AggregateUsecPerFileMetadataReadOp   *prometheus.Desc
+	AggregateUsecPerShareMetadataReadOp  *prometheus.Desc
+	CreatesPerSec                        *prometheus.Desc
+	FsinfosPerSec                        *prometheus.Desc
+	FsstatsPerSec                        *prometheus.Desc
+	GetattrsPerSec                       *prometheus.Desc
+	LinksPerSec                          *prometheus.Desc
+	LookupsPerSec                        *prometheus.Desc
+	MkdirsPerSec                         *prometheus.Desc
+	OthersPerSec                         *prometheus.Desc
+	PathconfsPerSec                      *prometheus.Desc
+	ReadsPerSec                          *prometheus.Desc
+	ReaddirsPerSec                       *prometheus.Desc
+	ReaddirplusesPerSec                  *prometheus.Desc
+	ReadlinksPerSec                      *prometheus.Desc
+	RemovesPerSec                        *prometheus.Desc
+	RenamesPerSec                        *prometheus.Desc
+	RmdirsPerSec                         *prometheus.Desc
+	SetattrsPerSec                       *prometheus.Desc
+	SymlinksPerSec                       *prometheus.Desc
+	WritesPerSec                         *prometheus.Desc
+	UsecPerAccessOp                      *prometheus.Desc
+	UsecPerCreateOp                      *prometheus.Desc
+	UsecPerFsinfoOp                      *prometheus.Desc
+	UsecPerFsstatOp                      *prometheus.Desc
+	UsecPerGetattrOp                     *prometheus.Desc
+	UsecPerLinkOp                        *prometheus.Desc
+	UsecPerLookupOp                      *prometheus.Desc
+	UsecPerMkdirOp                       *prometheus.Desc
+	UsecPerOtherOp                       *prometheus.Desc
+	UsecPerPathconfOp                    *prometheus.Desc
+	UsecPerReadOp                        *prometheus.Desc
+	UsecPerReaddirOp                     *prometheus.Desc
+	UsecPerReaddirPlusOp                 *prometheus.Desc
+	UsecPerReadlinkOp                    *prometheus.Desc
+	UsecPerRemoveOp                      *prometheus.Desc
+	UsecPerRenameOp                      *prometheus.Desc
+	UsecPerRmdirOp                       *prometheus.Desc
+	UsecPerSetattrOp                     *prometheus.Desc
+	UsecPerSymlinkOp                     *prometheus.Desc
+	UsecPerWriteOp                       *prometheus.Desc
+}
+
+func NewArrayNfsPerformanceCollector(fbClient *fb.FlashbladeClient) *ArrayNfsPerformanceCollector {
+	const subsystem = "perf_nfs"
+
+	return &ArrayNfsPerformanceCollector{
+		fbClient: fbClient,
+		AccessesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "accesses_per_sec"),
+			"ACCESS requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateFileMetadataCreatesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_file_metadata_creates_per_sec"),
+			"Sum of file-level or directory-level create-like metadata requests per second. Includes CREATE, LINK, MKDIR, and SYMLINK",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateFileMetadataModifiesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_file_metadata_modifies_per_sec"),
+			"Sum of file-level or directory-level modify-like and delete-like metadata requests per second. Includes REMOVE, RENAME, RMDIR, and SETATTR",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateFileMetadataReadsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_file_metadata_reads_per_sec"),
+			"Sum of file-level or directory-level read-like metadata requests per second. Includes GETATTR, LOOKUP, PATHCONF, READDIR, READDIRPLUS, and READLINK",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateShareMetadataReadsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_share_metadata_reads_per_sec"),
+			"Sum of share-level read-like metadata requests per second. Includes ACCESS, FSINFO, and FSSTAT",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateUsecPerFileMetadataCreateOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_usec_per_file_metadata_create_op"),
+			"Average time, measured in microseconds, it takes the array to process a file-level or directory-level create-like metadata request. Includes CREATE, LINK, MKDIR, and SYMLINK",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateUsecPerFileMetadataModifyOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_usec_per_file_metadata_modify_op"),
+			"Average time, measured in microseconds, it takes the array to process a file-level or directory-level modify-like or delete-like metadata request. Includes REMOVE, RENAME, RMDIR, and SETATTR",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateUsecPerFileMetadataReadOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_usec_per_file_metadata_read_op"),
+			"Average time, measured in microseconds, it takes the array to process a file-level or directory-level read-like metadata request. Includes GETATTR, LOOKUP, PATHCONF, READDIR, READDIRPLUS, and READLINK",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		AggregateUsecPerShareMetadataReadOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "aggregate_usec_per_share_metadata_read_op"),
+			"Average time, measured in microseconds, it takes the array to process a share-level read-like metadata request. Includes ACCESS, FSINFO, and FSSTAT",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		CreatesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "creates_per_sec"),
+			"CREATE requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		FsinfosPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "fsinfos_per_sec"),
+			"FSINFO requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		FsstatsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "fsstats_per_sec"),
+			"FSSTAT requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		GetattrsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "getattrs_per_sec"),
+			"GETATTR requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		LinksPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "links_per_sec"),
+			"LINK requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		LookupsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "lookups_per_sec"),
+			"LOOKUP requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		MkdirsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "mkdirs_per_sec"),
+			"MKDIR requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		OthersPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "others_per_sec"),
+			"All other requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		PathconfsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "pathconfs_per_sec"),
+			"PATHCONF requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "reads_per_sec"),
+			"READ requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReaddirsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "readdirs_per_sec"),
+			"READDIR requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReaddirplusesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "readdirpluses_per_sec"),
+			"READDIRPLUS requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadlinksPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "readlinks_per_sec"),
+			"READLINK requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		RemovesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "removes_per_sec"),
+			"REMOVE requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		RenamesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "renames_per_sec"),
+			"RENAME requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		RmdirsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "rmdirs_per_sec"),
+			"RMDIR requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		SetattrsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "setattrs_per_sec"),
+			"SETATTR requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		SymlinksPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "symlinks_per_sec"),
+			"SYMLINK requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WritesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "writes_per_sec"),
+			"WRITE requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerAccessOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_access_op"),
+			"Average time, measured in microseconds, it takes the array to process an ACCESS request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerCreateOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_create_op"),
+			"Average time, measured in microseconds, it takes the array to process a CREATE request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerFsinfoOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_fsinfo_op"),
+			"Average time, measured in microseconds, it takes the array to process an FSINFO request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerFsstatOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_fsstat_op"),
+			"Average time, measured in microseconds, it takes the array to process an FSSTAT request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerGetattrOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_getattr_op"),
+			"Average time, measured in microseconds, it takes the array to process a GETATTR request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerLinkOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_link_op"),
+			"Average time, measured in microseconds, it takes the array to process a LINK request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerLookupOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_lookup_op"),
+			"Average time, measured in microseconds, it takes the array to process a LOOKUP request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerMkdirOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_mkdir_op"),
+			"Average time, measured in microseconds, it takes the array to process a MKDIR request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerOtherOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_other_op"),
+			"Average time, measured in microseconds, it takes the array to process all other requests",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerPathconfOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_pathconf_op"),
+			"Average time, measured in microseconds, it takes the array to process a PATHCONF request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_read_op"),
+			"Average time, measured in microseconds, it takes the array to process a READ request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReaddirOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_readdir_op"),
+			"Average time, measured in microseconds, it takes the array to process a READDIR request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReaddirPlusOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_readdir_plus_op"),
+			"Average time, measured in microseconds, it takes the array to process a READDIRPLUS request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadlinkOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_readlink_op"),
+			"Average time, measured in microseconds, it takes the array to process a READLINK request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerRemoveOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_remove_op"),
+			"Average time, measured in microseconds, it takes the array to process a REMOVE request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerRenameOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_rename_op"),
+			"Average time, measured in microseconds, it takes the array to process a RENAME request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerRmdirOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_rmdir_op"),
+			"Average time, measured in microseconds, it takes the array to process an RMDIR request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerSetattrOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_setattr_op"),
+			"Average time, measured in microseconds, it takes the array to process a SETATTR request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerSymlinkOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_symlink_op"),
+			"Average time, measured in microseconds, it takes the array to process a SYMLINK request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_write_op"),
+			"Average time, measured in microseconds, it takes the array to process a WRITE request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c ArrayNfsPerformanceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting array NFS performance metrics", err)
+	}
+}
+
+func (c ArrayNfsPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
+	stats, err := c.fbClient.ArrayNfsPerformance()
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AccessesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AccessesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateFileMetadataCreatesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateFileMetadataCreatesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateFileMetadataModifiesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateFileMetadataModifiesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateFileMetadataReadsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateFileMetadataReadsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateShareMetadataReadsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateShareMetadataReadsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateUsecPerFileMetadataCreateOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateUsecPerFileMetadataCreateOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateUsecPerFileMetadataModifyOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateUsecPerFileMetadataModifyOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateUsecPerFileMetadataReadOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateUsecPerFileMetadataReadOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.AggregateUsecPerShareMetadataReadOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].AggregateUsecPerShareMetadataReadOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.CreatesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].CreatesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FsinfosPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].FsinfosPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.FsstatsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].FsstatsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.GetattrsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].GetattrsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.LinksPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].LinksPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.LookupsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].LookupsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.MkdirsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].MkdirsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.OthersPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].OthersPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.PathconfsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].PathconfsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].CreatesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReaddirsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReaddirsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReaddirplusesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReaddirplusesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadlinksPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReadlinksPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.RemovesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].RemovesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.RenamesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].RenamesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.RmdirsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].RmdirsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.SetattrsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].SetattrsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.SymlinksPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].SymlinksPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.WritesPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].WritesPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerAccessOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerAccessOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerCreateOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerCreateOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerFsinfoOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerFsinfoOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerFsstatOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerFsstatOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerGetattrOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerGetattrOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerLinkOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerLinkOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerLookupOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerLookupOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerMkdirOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerMkdirOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerOtherOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerOtherOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerPathconfOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerPathconfOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReaddirOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReaddirOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReaddirPlusOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReaddirPlusOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadlinkOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadlinkOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerRemoveOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerRemoveOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerRenameOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerRenameOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerRmdirOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerRmdirOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerSetattrOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerSetattrOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerSymlinkOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerSymlinkOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerWriteOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerWriteOp))
+
+	return nil
+}

--- a/collector/array_s3_performance.go
+++ b/collector/array_s3_performance.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package collector
+
+import (
+	"github.com/man-group/prometheus-flashblade-exporter/fb"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type ArrayS3PerformanceCollector struct {
+	fbClient             *fb.FlashbladeClient
+	ReadBucketsPerSec    *prometheus.Desc
+	WriteBucketsPerSec   *prometheus.Desc
+	ReadObjectsPerSec    *prometheus.Desc
+	WriteObjectsPerSec   *prometheus.Desc
+	OthersPerSec         *prometheus.Desc
+	UsecPerReadBucketOp  *prometheus.Desc
+	UsecPerWriteBucketOp *prometheus.Desc
+	UsecPerReadObjectOp  *prometheus.Desc
+	UsecPerWriteObjectOp *prometheus.Desc
+	UsecPerOtherOp       *prometheus.Desc
+}
+
+func NewArrayS3PerformanceCollector(fbClient *fb.FlashbladeClient) *ArrayS3PerformanceCollector {
+	const subsystem = "perf_s3"
+
+	return &ArrayS3PerformanceCollector{
+		fbClient: fbClient,
+		ReadBucketsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_buckets_per_sec"),
+			"Read bucket requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteBucketsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_buckets_per_sec"),
+			"Write bucket requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadObjectsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_objects_per_sec"),
+			"Read object requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteObjectsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_objects_per_sec"),
+			"Write object requests processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		OthersPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "others_per_sec"),
+			"Other operations processed per second",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadBucketOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_read_bucket_op"),
+			"Average time, measured in microseconds, that the array takes to process a read bucket request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteBucketOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_write_bucket_op"),
+			"Average time, measured in microseconds, that the array takes to process a write bucket request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadObjectOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_read_object_op"),
+			"Average time, measured in microseconds, that the array takes to process a read object request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteObjectOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_write_object_op"),
+			"Average time, measured in microseconds, that the array takes to process a write object request",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerOtherOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "usec_per_other_op"),
+			"Average time, measured in microseconds, that the array takes to process other operations",
+			nil,
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c ArrayS3PerformanceCollector) collect(ch chan<- prometheus.Metric) error {
+	stats, err := c.fbClient.ArrayS3Performance()
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadBucketsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReadBucketsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.WriteBucketsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].WriteBucketsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.ReadObjectsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].ReadObjectsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.WriteObjectsPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].WriteObjectsPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.OthersPerSec,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].OthersPerSec))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadBucketOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadBucketOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerWriteBucketOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerWriteBucketOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerReadObjectOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerReadObjectOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerWriteObjectOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerWriteObjectOp))
+
+	ch <- prometheus.MustNewConstMetric(
+		c.UsecPerOtherOp,
+		prometheus.GaugeValue,
+		float64(stats.Items[0].UsecPerOtherOp))
+
+	return nil
+}
+
+func (c ArrayS3PerformanceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting array S3 performance metrics", err)
+	}
+}

--- a/collector/array_space.go
+++ b/collector/array_space.go
@@ -65,7 +65,7 @@ func NewArraySpaceCollector(fbClient *fb.FlashbladeClient) *ArraySpaceCollector 
 
 func (c ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 	if err := c.collect(ch); err != nil {
-		log.Error("Failed collecting array performance metrics", err)
+		log.Error("Failed collecting array space metrics", err)
 	}
 }
 

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -27,6 +27,9 @@ type FlashbladeCollector struct {
 func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool, fsFilterFlag string) *FlashbladeCollector {
 	alertsCollector := NewAlertsCollector(fbClient)
 	arrayPerformanceCollector := NewArrayPerformanceCollector(fbClient)
+	arrayNfsPerformanceCollector := NewArrayNfsPerformanceCollector(fbClient)
+	arrayHttpPerformanceCollector := NewArrayHttpPerformanceCollector(fbClient)
+	arrayS3PerformanceCollector := NewArrayS3PerformanceCollector(fbClient)
 	arraySpaceCollector := NewArraySpaceCollector(fbClient)
 	bladesCollector := NewBladesCollector(fbClient)
 	filesystemsCollector := NewFilesystemsCollector(fbClient)
@@ -35,6 +38,9 @@ func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool, fs
 	subcollectors := []Subcollector{
 		alertsCollector,
 		arrayPerformanceCollector,
+		arrayHttpPerformanceCollector,
+		arrayNfsPerformanceCollector,
+		arrayS3PerformanceCollector,
 		arraySpaceCollector,
 		bladesCollector,
 		filesystemsCollector,

--- a/fb/array_http_performance.go
+++ b/fb/array_http_performance.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package fb
+
+type ArrayHttpPerformanceResponse struct {
+	Items [1]ArrayHttpPerformanceItem `json:"items"`
+}
+
+type ArrayHttpPerformanceItem struct {
+	Name               string  `json:"name"`
+	ReadDirsPerSec     float64 `json:"read_dirs_per_sec"`
+	WriteDirsPerSec    float64 `json:"write_dirs_per_sec"`
+	ReadFilesPerSec    float64 `json:"read_files_per_sec"`
+	WriteFilesPerSec   float64 `json:"write_files_per_sec"`
+	OthersPerSec       float64 `json:"others_per_sec"`
+	UsecPerReadDirOp   float64 `json:"usec_per_read_dir_op"`
+	UsecPerWriteDirOp  float64 `json:"usec_per_write_dir_op"`
+	UsecPerReadFileOp  float64 `json:"usec_per_read_file_op"`
+	UsecPerWriteFileOp float64 `json:"usec_per_write_file_op"`
+	UsecPerOtherOp     float64 `json:"usec_per_other_op"`
+	Time               float64 `json:"time"`
+}
+
+func (fbClient FlashbladeClient) ArrayHttpPerformance() (ArrayHttpPerformanceResponse, error) {
+	endpoint := "arrays/http-specific-performance"
+	var arrayHttpPerformanceResponse ArrayHttpPerformanceResponse
+	err := fbClient.GetJSON(endpoint, nil, &arrayHttpPerformanceResponse)
+	return arrayHttpPerformanceResponse, err
+}

--- a/fb/array_nfs_performance.go
+++ b/fb/array_nfs_performance.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package fb
+
+type ArrayNfsPerformanceResponse struct {
+	Items [1]ArrayNfsPerformanceItem `json:"items"`
+}
+
+type ArrayNfsPerformanceItem struct {
+	Id                                   string  `json:"id"`
+	Name                                 string  `json:"name"`
+	AccessesPerSec                       float64 `json:"accesses_per_sec"`
+	AggregateFileMetadataCreatesPerSec   float64 `json:"aggregate_file_metadata_creates_per_sec"`
+	AggregateFileMetadataModifiesPerSec  float64 `json:"aggregate_file_metadata_modifies_per_sec"`
+	AggregateFileMetadataReadsPerSec     float64 `json:"aggregate_file_metadata_reads_per_sec"`
+	AggregateShareMetadataReadsPerSec    float64 `json:"aggregate_share_metadata_reads_per_sec"`
+	AggregateUsecPerFileMetadataCreateOp float64 `json:"aggregate_usec_per_file_metadata_create_op"`
+	AggregateUsecPerFileMetadataModifyOp float64 `json:"aggregate_usec_per_file_metadata_modify_op"`
+	AggregateUsecPerFileMetadataReadOp   float64 `json:"aggregate_usec_per_file_metadata_read_op"`
+	AggregateUsecPerShareMetadataReadOp  float64 `json:"aggregate_usec_per_share_metadata_read_op"`
+	CreatesPerSec                        float64 `json:"creates_per_sec"`
+	FsinfosPerSec                        float64 `json:"fsinfos_per_sec"`
+	FsstatsPerSec                        float64 `json:"fsstats_per_sec"`
+	GetattrsPerSec                       float64 `json:"getattrs_per_sec"`
+	LinksPerSec                          float64 `json:"links_per_sec"`
+	LookupsPerSec                        float64 `json:"lookups_per_sec"`
+	MkdirsPerSec                         float64 `json:"mkdirs_per_sec"`
+	OthersPerSec                         float64 `json:"others_per_sec"`
+	PathconfsPerSec                      float64 `json:"pathconfs_per_sec"`
+	ReadsPerSec                          float64 `json:"reads_per_sec"`
+	ReaddirsPerSec                       float64 `json:"readdirs_per_sec"`
+	ReaddirplusesPerSec                  float64 `json:"readdirpluses_per_sec"`
+	ReadlinksPerSec                      float64 `json:"readlinks_per_sec"`
+	RemovesPerSec                        float64 `json:"removes_per_sec"`
+	RenamesPerSec                        float64 `json:"renames_per_sec"`
+	RmdirsPerSec                         float64 `json:"rmdirs_per_sec"`
+	SetattrsPerSec                       float64 `json:"setattrs_per_sec"`
+	SymlinksPerSec                       float64 `json:"symlinks_per_sec"`
+	Time                                 float64 `json:"time"`
+	WritesPerSec                         float64 `json:"writes_per_sec"`
+	UsecPerAccessOp                      float64 `json:"usec_per_access_op"`
+	UsecPerCreateOp                      float64 `json:"usec_per_create_op"`
+	UsecPerFsinfoOp                      float64 `json:"usec_per_fsinfo_op"`
+	UsecPerFsstatOp                      float64 `json:"usec_per_fsstat_op"`
+	UsecPerGetattrOp                     float64 `json:"usec_per_getattr_op"`
+	UsecPerLinkOp                        float64 `json:"usec_per_link_op"`
+	UsecPerLookupOp                      float64 `json:"usec_per_lookup_op"`
+	UsecPerMkdirOp                       float64 `json:"usec_per_mkdir_op"`
+	UsecPerOtherOp                       float64 `json:"usec_per_other_op"`
+	UsecPerPathconfOp                    float64 `json:"usec_per_pathconf_op"`
+	UsecPerReadOp                        float64 `json:"usec_per_read_op"`
+	UsecPerReaddirOp                     float64 `json:"usec_per_readdir_op"`
+	UsecPerReaddirPlusOp                 float64 `json:"usec_per_readdirplus_op"`
+	UsecPerReadlinkOp                    float64 `json:"usec_per_readlink_op"`
+	UsecPerRemoveOp                      float64 `json:"usec_per_remove_op"`
+	UsecPerRenameOp                      float64 `json:"usec_per_rename_op"`
+	UsecPerRmdirOp                       float64 `json:"usec_per_rmdir_op"`
+	UsecPerSetattrOp                     float64 `json:"usec_per_setattr_op"`
+	UsecPerSymlinkOp                     float64 `json:"usec_per_symlink_op"`
+	UsecPerWriteOp                       float64 `json:"usec_per_write_op"`
+}
+
+func (fbClient FlashbladeClient) ArrayNfsPerformance() (ArrayNfsPerformanceResponse, error) {
+	endpoint := "arrays/nfs-specific-performance"
+	var arrayNfsPerformanceResponse ArrayNfsPerformanceResponse
+	err := fbClient.GetJSON(endpoint, nil, &arrayNfsPerformanceResponse)
+	return arrayNfsPerformanceResponse, err
+}

--- a/fb/array_s3_performance.go
+++ b/fb/array_s3_performance.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 by the authors in the project README.md
+// See the full license in the project LICENSE file.
+
+package fb
+
+type ArrayS3PerformanceResponse struct {
+	Items [1]ArrayS3PerformanceItem `json:"items"`
+}
+
+type ArrayS3PerformanceItem struct {
+	Name                 string  `json:"name"`
+	ReadBucketsPerSec    float64 `json:"read_buckets_per_sec"`
+	WriteBucketsPerSec   float64 `json:"write_buckets_per_sec"`
+	ReadObjectsPerSec    float64 `json:"read_objects_per_sec"`
+	WriteObjectsPerSec   float64 `json:"write_objects_per_sec"`
+	OthersPerSec         float64 `json:"others_per_sec"`
+	UsecPerReadBucketOp  float64 `json:"usec_per_read_bucket_op"`
+	UsecPerWriteBucketOp float64 `json:"usec_per_write_bucket_op"`
+	UsecPerReadObjectOp  float64 `json:"usec_per_read_object_op"`
+	UsecPerWriteObjectOp float64 `json:"usec_per_write_object_op"`
+	UsecPerOtherOp       float64 `json:"usec_per_other_op"`
+	Time                 float64 `json:"time"`
+}
+
+func (fbClient FlashbladeClient) ArrayS3Performance() (ArrayS3PerformanceResponse, error) {
+	endpoint := "arrays/s3-specific-performance"
+	var arrayS3PerformanceResponse ArrayS3PerformanceResponse
+	err := fbClient.GetJSON(endpoint, nil, &arrayS3PerformanceResponse)
+	return arrayS3PerformanceResponse, err
+}

--- a/fb/usage.go
+++ b/fb/usage.go
@@ -52,14 +52,14 @@ type NameID struct {
 }
 
 func filterFilesystems(vs []FilesystemsItem, regexMatch string) []FilesystemsItem {
-    vsf := make([]FilesystemsItem, 0)
-    for _, v := range vs {
-        matched, _ := regexp.MatchString(regexMatch, v.Name)
-        if matched {
-            vsf = append(vsf, v)
-        }
-    }
-    return vsf
+	vsf := make([]FilesystemsItem, 0)
+	for _, v := range vs {
+		matched, _ := regexp.MatchString(regexMatch, v.Name)
+		if matched {
+			vsf = append(vsf, v)
+		}
+	}
+	return vsf
 }
 
 // With the default value of fsFilterFlag, this function makes a call for every filesystem, which

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var (
 	fsMetricFlag   = kingpin.Flag("filesystem-metrics", "Export filesystem and usage data metrics for each user and group.").Default("false").Bool()
 	fsFilterFlag   = kingpin.Flag("filesystem-filter-regexp", "Regexp limiting the filesystems for which metrics are exported").Default(".*").String()
 	insecureFlag   = kingpin.Flag("insecure", "Disable the verification of the SSL certificate").Default("false").Bool()
-	apiVersionFlag = kingpin.Flag("api-version", "API version to query the flashblade").Default("1.7").String()
+	apiVersionFlag = kingpin.Flag("api-version", "API version to query the flashblade").Default("1.8").String()
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func listen() {
 }
 
 func main() {
-	kingpin.Version("0.4.1")
+	kingpin.Version("0.5.0")
 	kingpin.Parse()
 	fbClient := fb.NewFlashbladeClient(*flashbladeFlag, *insecureFlag, *apiVersionFlag)
 	fbCollector := collector.NewFlashbladeCollector(fbClient, *fsMetricFlag, *fsFilterFlag)


### PR DESCRIPTION
This change adds NFS, HTTP and S3 protocol specific metrics, some of which are quite interesting.

The NFS metrics which give a dedicated breakdown by NFS operation type require API version 1.9.