### PR TITLE
add per user counters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all: build
 build:
 	CGO_ENABLED=0 go build -ldflags '-w -extldflags "-static"'
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -extldflags "-static"' -o prometheus-flashblade-exporter.linux
 docker:
 	docker build

--- a/collector/collectors.go
+++ b/collector/collectors.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/man-group/prometheus-flashblade-exporter/fb"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -50,8 +49,9 @@ func NewFlashbladeCollector(fbClient *fb.FlashbladeClient, fsMetricFlag bool, fs
 	if fsMetricFlag {
 		usageCollector := NewUsageCollector(fbClient, fsFilterFlag)
 		fsPerformanceCollector := NewFSPerformanceCollector(fbClient)
+		fSByUserPerformanceCollector := NewFSByUserPerformanceCollector(fbClient)
 
-		subcollectors = append(subcollectors, usageCollector, fsPerformanceCollector)
+		subcollectors = append(subcollectors, usageCollector, fsPerformanceCollector, fSByUserPerformanceCollector)
 	}
 
 	return &FlashbladeCollector{subcollectors: subcollectors}

--- a/collector/fs_performance.go
+++ b/collector/fs_performance.go
@@ -4,6 +4,7 @@
 package collector
 
 import (
+	"fmt"
 	"github.com/man-group/prometheus-flashblade-exporter/fb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -188,6 +189,198 @@ func (c FSPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
 			float64(stat.WriteBytesPerSec),
 			stat.Name,
 		)
+	}
+
+	return nil
+}
+
+type FSByUserPerformanceCollector struct {
+	fbClient         *fb.FlashbladeClient
+	BytesPerOp       *prometheus.Desc
+	BytesPerRead     *prometheus.Desc
+	BytesPerWrite    *prometheus.Desc
+	OthersPerSec     *prometheus.Desc
+	ReadsPerSec      *prometheus.Desc
+	ReadBytesPerSec  *prometheus.Desc
+	UsecPerOtherOp   *prometheus.Desc
+	UsecPerReadOp    *prometheus.Desc
+	UsecPerWriteOp   *prometheus.Desc
+	WritesPerSec     *prometheus.Desc
+	WriteBytesPerSec *prometheus.Desc
+}
+
+func NewFSByUserPerformanceCollector(fbClient *fb.FlashbladeClient) *FSByUserPerformanceCollector {
+	const subsystem = "fs_user_performance"
+
+	return &FSByUserPerformanceCollector{
+		fbClient: fbClient,
+		BytesPerOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_operation"),
+			"Average operation size (read bytes+write bytes/(read operations + write operations))",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		BytesPerRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_read"),
+			"Average read size in bytes per read operation",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		BytesPerWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "bytes_per_write"),
+			"Average write size in bytes per write operation",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		OthersPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "non_read_write_operations_per_second"),
+			"All operations except read processed per second",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadsPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "reads_per_second"),
+			"Read requests processed per second",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		ReadBytesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "read_bytes_per_second"),
+			"Read byte requests processed per second",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerOtherOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_non_read_write_operation"),
+			"Average time, measured in seconds, that the array takes to process other operations",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerReadOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_read_operation"),
+			"Average time, measured in seconds, that the array takes to process a read request",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		UsecPerWriteOp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "seconds_per_write_operation"),
+			"Average time, measured in seconds, that the array takes to process a write request",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+
+		WritesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "writes_per_second"),
+			"Write requests processed per second",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+		WriteBytesPerSec: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "write_bytes_per_second"),
+			"Write byte requests processed per second",
+			[]string{"name", "filesystem"},
+			prometheus.Labels{"host": fbClient.Host},
+		),
+	}
+}
+
+func (c FSByUserPerformanceCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(ch); err != nil {
+		log.Error("Failed collecting quota metrics", err)
+	}
+}
+
+func (c FSByUserPerformanceCollector) collect(ch chan<- prometheus.Metric) error {
+	filesystems, err := c.fbClient.FSPerformanceByUser()
+	if err != nil {
+		return err
+	}
+
+	for _, fs := range filesystems {
+		for _, stat := range fs.Items {
+			// we hit HTTP 500 errors if stat.User.Name is "", i think because
+			//	promtheus cannot create a valid label. as for *why* Name is "",
+			//	if the uid is not in ldap, then the flashblade cant resolve a username
+			if stat.User.Name == "" {
+				stat.User.Name = fmt.Sprintf("%d", stat.User.Id)
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.BytesPerOp,
+				prometheus.GaugeValue,
+				float64(stat.BytesPerOp),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.BytesPerRead,
+				prometheus.GaugeValue,
+				float64(stat.BytesPerRead),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.BytesPerWrite,
+				prometheus.GaugeValue,
+				float64(stat.BytesPerWrite),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.OthersPerSec,
+				prometheus.GaugeValue,
+				float64(stat.OthersPerSec),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.ReadsPerSec,
+				prometheus.GaugeValue,
+				float64(stat.ReadsPerSec),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.ReadBytesPerSec,
+				prometheus.GaugeValue,
+				float64(stat.ReadBytesPerSec),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.UsecPerOtherOp,
+				prometheus.GaugeValue,
+				float64(stat.UsecPerOtherOp)/1e6,
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.UsecPerReadOp,
+				prometheus.GaugeValue,
+				float64(stat.UsecPerReadOp)/1e6,
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.UsecPerWriteOp,
+				prometheus.GaugeValue,
+				float64(stat.UsecPerWriteOp)/1e6,
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.WritesPerSec,
+				prometheus.GaugeValue,
+				float64(stat.WritesPerSec),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				c.WriteBytesPerSec,
+				prometheus.GaugeValue,
+				float64(stat.WriteBytesPerSec),
+				stat.User.Name, stat.FileSystem.Name,
+			)
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/man-group/prometheus-flashblade-exporter
 
-go 1.12
+go 1.16
 
 require (
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -12,12 +13,14 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
@@ -33,11 +36,13 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5 h1:mzjBh+S5frKOsOBobWIMAbXavqjmgO17k/2puhcFR94=


### PR DESCRIPTION
This change adds support for capturing per user statistics per file system, which was added around Purity OS 3.2.7ish.

